### PR TITLE
Fix prop type validation

### DIFF
--- a/src/ParallaxSwiper.js
+++ b/src/ParallaxSwiper.js
@@ -217,7 +217,7 @@ ParallaxSwiper.propTypes = {
   showsHorizontalScrollIndicator: PropTypes.bool,
   onMomentumScrollEnd: PropTypes.func,
   children: PropTypes.arrayOf((propValue, key, componentName) => {
-    const childComponentName = propValue[key].type.displayName;
+    const childComponentName = propValue[key].type.displayName || propValue[key].type.name;
     if (!/ParallaxSwiperPage/.test(childComponentName)) {
       return new Error(
         `Invalid component '${childComponentName}' supplied to ${componentName}. Use 'ParallaxSwiperPage' instead.`,


### PR DESCRIPTION
`type.displayName` is provided by React.
`type.name` is provided by JavaScript.

We were getting warnings in our test suite like:

```
Warning: Failed prop type: Invalid prop `children` of type `object` supplied to `ParallaxSwiper`, expected an array.        in ParallaxSwiper (created by class_1)        in class_1 (created by ConnectFunction)
```